### PR TITLE
support for queries by filetype

### DIFF
--- a/lua/SelectEase/lib/get_ts_nodes.lua
+++ b/lua/SelectEase/lib/get_ts_nodes.lua
@@ -36,9 +36,14 @@ local get_parser_name_and_root = function()
     end
 end
 
-M.get_nodes_from_query = function(query)
+M.get_nodes_from_query = function(query, queries)
     local parser_name, root = get_parser_name_and_root()
     local nodes = {}
+
+    query = queries[parser_name] or query
+    if query == nil then
+        return {}
+    end
 
     local iter_query = vim.treesitter.query.parse_query(parser_name, query)
     for _, matches, _ in iter_query:iter_matches(root) do

--- a/lua/SelectEase/lib/select_ts_nodes.lua
+++ b/lua/SelectEase/lib/select_ts_nodes.lua
@@ -153,7 +153,8 @@ local vertical_drill_jump = function(opts, nodes, cursor_row, cursor_col)
 end
 
 M.select_node = function(opts)
-    local nodes = lib_get_ts_nodes.get_nodes_from_query(opts.query)
+    local queries = opts.queries or {}
+    local nodes = lib_get_ts_nodes.get_nodes_from_query(opts.query, queries)
     local cursor = vim.api.nvim_win_get_cursor(0)
     local cursor_row, cursor_col = cursor[1] - 1, cursor[2]
 


### PR DESCRIPTION
Currently, `select_node` only supports a single query which is not ideal when queries are language-dependent. For example, the query in the README is not compatible with python.

This is a simple change that allows passing in a table mapping a filetype to a query to use for that filetype: `select_ease.select_node({ queries = { python = query }, direction = "next" })`. This is a non-breaking change as `query` will be used if `queries` is not passed in. If this PR looks good, I can go ahead and update the README before merging.